### PR TITLE
Sim motor timeouts

### DIFF
--- a/simulator/simulator.hpp
+++ b/simulator/simulator.hpp
@@ -84,6 +84,7 @@ namespace mrover {
             int index{};
             boost::container::small_vector<Uniform<ModelUniforms>, 2> visualUniforms;
             boost::container::small_vector<Uniform<ModelUniforms>, 2> collisionUniforms;
+            Clock::time_point lastUpdate = Clock::now();
         };
 
         urdf::Model model;
@@ -362,7 +363,7 @@ namespace mrover {
             }
 
             if (auto it = mUrdfs.find("rover"); it != mUrdfs.end()) {
-                URDF const& rover = it->second;
+                URDF& rover = it->second;
 
                 for (std::size_t i = 0; i < names.size(); ++i) {
                     std::string const& name = names[i];
@@ -375,7 +376,8 @@ namespace mrover {
                     }
 
                     std::string const& urdfName = it->second;
-                    URDF::LinkMeta const& linkMeta = rover.linkNameToMeta.at(urdfName);
+                    URDF::LinkMeta& linkMeta = rover.linkNameToMeta.at(urdfName);
+                    linkMeta.lastUpdate = Clock::now();
 
                     auto* motor = std::bit_cast<btMultiBodyJointMotor*>(rover.physics->getLink(linkMeta.index).m_userPtr);
                     assert(motor);

--- a/simulator/simulator.physics.cpp
+++ b/simulator/simulator.physics.cpp
@@ -54,7 +54,7 @@ namespace mrover {
                 motor->setPositionTarget(0);
             }
             // check if arm motor commands have expired
-            // TODO(quintin): fix hard-coded names?
+            // TODO: fix hard-coded names?
             for (auto const& name : {"arm_a_link", "arm_b_link", "arm_c_link", "arm_d_link", "arm_e_link"}) {
                 bool expired = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - rover.linkNameToMeta.at(name).lastUpdate).count() > 20;
                 if (expired) {

--- a/simulator/simulator.physics.cpp
+++ b/simulator/simulator.physics.cpp
@@ -53,6 +53,19 @@ namespace mrover {
                 motor->setMaxAppliedImpulse(0.5);
                 motor->setPositionTarget(0);
             }
+            // check if arm motor commands have expired
+            // TODO(quintin): fix hard-coded names?
+            for (auto const& name : {"arm_a_link", "arm_b_link", "arm_c_link", "arm_d_link", "arm_e_link"}) {
+                bool expired = std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - rover.linkNameToMeta.at(name).lastUpdate).count() > 20;
+                if (expired) {
+                    int linkIndex = rover.linkNameToMeta.at(name).index;
+                    auto* motor = std::bit_cast<btMultiBodyJointMotor*>(rover.physics->getLink(linkIndex).m_userPtr);
+                    assert(motor);
+                    motor->setVelocityTarget(0, 1);
+                    // set p gain to 0 to stop position control
+                    motor->setPositionTarget(0, 0);
+                }
+            }
         }
 
         float updateDuration = std::clamp(std::chrono::duration_cast<std::chrono::duration<float>>(dt).count(), 0.0f, 0.1f);


### PR DESCRIPTION
## Summary

What features did you add, bugs did you fix, etc? 
Added motor timeouts to the arm in the simulator to better mimic the real rover.

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested by publishing to `/arm_ik` with `ros2 topic pub --once /arm_ik mrover/msg/IK "{target: {header: {frame_id: 'arm_base_link'}, pose: {position: {x: 0.382, y: 0.01, z: -0.217}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}"` (arm moves briefly before timing out, as expected).

### Did you test this in sim? 
Yes

### Did you test this on the rover?
N/A

### Did you add unit tests? 
No
