### PR TITLE
Add timestamps to TF publishing from conversions.py

### DIFF
--- a/lie/conversions.py
+++ b/lie/conversions.py
@@ -16,12 +16,13 @@ def to_tf_tree(
     se3: SE3,
     child_frame: str,
     parent_frame: str,
+    stamp: Time
 ) -> None:
     tx, ty, tz = se3.translation()
     qx, qy, qz, qw = se3.quat()
     tf_broadcaster.sendTransform(
         TransformStamped(
-            header=Header(frame_id=parent_frame),
+            header=Header(frame_id=parent_frame, stamp=stamp),
             child_frame_id=child_frame,
             transform=Transform(
                 translation=Vector3(x=tx, y=ty, z=tz),

--- a/lie/conversions.py
+++ b/lie/conversions.py
@@ -16,7 +16,7 @@ def to_tf_tree(
     se3: SE3,
     child_frame: str,
     parent_frame: str,
-    stamp: Time
+    stamp: Time,
 ) -> None:
     tx, ty, tz = se3.translation()
     qx, qy, qz, qw = se3.quat()

--- a/navigation/context.py
+++ b/navigation/context.py
@@ -269,7 +269,7 @@ def setup_course(ctx: Context, waypoints: list[tuple[Waypoint, SE3]]) -> Course:
     all_waypoint_info = []
     for index, (waypoint_info, waypoint_in_world) in enumerate(waypoints):
         all_waypoint_info.append(waypoint_info)
-        SE3.to_tf_tree(ctx.tf_broadcaster, waypoint_in_world, f"course{index}", ctx.world_frame)
+        SE3.to_tf_tree(ctx.tf_broadcaster, waypoint_in_world, f"course{index}", ctx.world_frame, ctx.node.get_clock().now().to_msg())
     # Make the course out of just the pure waypoint objects which is the 0th element in the tuple
     return Course(
         ctx=ctx,

--- a/navigation/context.py
+++ b/navigation/context.py
@@ -269,7 +269,13 @@ def setup_course(ctx: Context, waypoints: list[tuple[Waypoint, SE3]]) -> Course:
     all_waypoint_info = []
     for index, (waypoint_info, waypoint_in_world) in enumerate(waypoints):
         all_waypoint_info.append(waypoint_info)
-        SE3.to_tf_tree(ctx.tf_broadcaster, waypoint_in_world, f"course{index}", ctx.world_frame, ctx.node.get_clock().now().to_msg())
+        SE3.to_tf_tree(
+            ctx.tf_broadcaster,
+            waypoint_in_world,
+            f"course{index}",
+            ctx.world_frame,
+            ctx.node.get_clock().now().to_msg(),
+        )
     # Make the course out of just the pure waypoint objects which is the 0th element in the tuple
     return Course(
         ctx=ctx,


### PR DESCRIPTION
## Summary
Closes #73 

What features did you add, bugs did you fix, etc? 
Added timestamping to the python to_tf_tree() function. Prior to this, the courses being published by nav had invalid timestamps and would time out as an old transform

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested in the sim using navigation and debug course publisher, verified that the timestamp parameter in the header was populated.

### Did you test this in sim? 
Yes

### Did you test this on the rover?
Sort of

### Did you add unit tests? 
No
