### PR TITLE
Allow enum to be defined as int parameter

### DIFF
--- a/parameter_utils/parameter.hpp
+++ b/parameter_utils/parameter.hpp
@@ -1,112 +1,116 @@
 #pragma once
 
-#include <vector>
-#include <string>
-#include <variant>
 #include <exception>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
+#include <variant>
+#include <vector>
 
 // Overloads pattern for visit
-template<class... Ts> struct overload : Ts... { using Ts::operator()...; };
-template<class... Ts> overload(Ts...) -> overload<Ts...>;
+template<class... Ts>
+struct overload : Ts... {
+    using Ts::operator()...;
+};
+template<class... Ts>
+overload(Ts...) -> overload<Ts...>;
 
 
 namespace mrover {
-	template<typename T>
-	concept IsIntEnum = std::is_enum_v<T> && std::is_same_v<std::underlying_type_t<T>, int>;
+    template<typename T>
+    concept IsIntEnum = std::is_enum_v<T> && std::is_same_v<std::underlying_type_t<T>, int>;
 
-	class ParameterWrapper {
-	private:
-		static inline std::shared_ptr<rclcpp::ParameterCallbackHandle> cbHande;
-		
-	public:
-		rclcpp::ParameterType mType;
+    class ParameterWrapper {
+    private:
+        static inline std::shared_ptr<rclcpp::ParameterCallbackHandle> cbHande;
 
-		std::string mParamDescriptor;
+    public:
+        rclcpp::ParameterType mType;
 
-		std::variant<int*, std::string*, bool*, double*, float*> mData;
+        std::string mParamDescriptor;
 
-		std::variant<int, std::string, bool, double, float> mDefaultValue;
+        std::variant<int*, std::string*, bool*, double*, float*> mData;
 
-		ParameterWrapper(std::string paramDescriptor, int& variable, int defaultValue = 0) : mType{rclcpp::ParameterType::PARAMETER_INTEGER}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue}{}
+        std::variant<int, std::string, bool, double, float> mDefaultValue;
 
-		ParameterWrapper(std::string paramDescriptor, std::string& variable, std::string defaultValue = "") : mType{rclcpp::ParameterType::PARAMETER_STRING}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{std::move(defaultValue)}{}
+        ParameterWrapper(std::string paramDescriptor, int& variable, int defaultValue = 0) : mType{rclcpp::ParameterType::PARAMETER_INTEGER}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue} {}
 
-		ParameterWrapper(std::string paramDescriptor, bool& variable, bool defaultValue = false) : mType{rclcpp::ParameterType::PARAMETER_BOOL}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue}{}
+        ParameterWrapper(std::string paramDescriptor, std::string& variable, std::string defaultValue = "") : mType{rclcpp::ParameterType::PARAMETER_STRING}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{std::move(defaultValue)} {}
 
-		ParameterWrapper(std::string paramDescriptor, double& variable, double defaultValue = 0.0) : mType{rclcpp::ParameterType::PARAMETER_DOUBLE}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue}{}
+        ParameterWrapper(std::string paramDescriptor, bool& variable, bool defaultValue = false) : mType{rclcpp::ParameterType::PARAMETER_BOOL}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue} {}
 
-		ParameterWrapper(std::string paramDescriptor, float& variable, float defaultValue = 0.0) : mType{rclcpp::ParameterType::PARAMETER_DOUBLE}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue}{}
+        ParameterWrapper(std::string paramDescriptor, double& variable, double defaultValue = 0.0) : mType{rclcpp::ParameterType::PARAMETER_DOUBLE}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue} {}
+
+        ParameterWrapper(std::string paramDescriptor, float& variable, float defaultValue = 0.0) : mType{rclcpp::ParameterType::PARAMETER_DOUBLE}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue} {}
 
         template<IsIntEnum T>
         ParameterWrapper(std::string paramDescriptor, T& variable, T defaultValue) : mType{rclcpp::ParameterType::PARAMETER_INTEGER}, mParamDescriptor{std::move(paramDescriptor)}, mData{reinterpret_cast<int*>(&variable)}, mDefaultValue{static_cast<int>(defaultValue)} {}
 
-		void visit(rclcpp::Node* node){
-			std::visit(overload{
-				[&](int* arg){
-					try{
-						*arg = static_cast<int>(node->get_parameter(mParamDescriptor).as_int());
-					}catch(rclcpp::exceptions::ParameterUninitializedException& e){
-						try{
-							*arg = std::get<int>(mDefaultValue);
-						}catch (std::bad_variant_access const& ex){
-							throw std::runtime_error("Bad Variant Access: Type not int");
-						}
-					}
-				},
-				[&](std::string* arg){
-					try{
-							*arg = node->get_parameter(mParamDescriptor).as_string();
-					}catch(rclcpp::exceptions::ParameterUninitializedException& e){
-						try{
-							*arg = std::get<std::string>(mDefaultValue);
-						}catch (std::bad_variant_access const& ex){
-							throw std::runtime_error("Bad Variant Access: Type not std::string");
-						}
-					}
-				},
-				[&](bool* arg){
-					try{
-						*arg = node->get_parameter(mParamDescriptor).as_bool();
-					}catch(rclcpp::exceptions::ParameterUninitializedException& e){
-						try{
-							*arg = std::get<bool>(mDefaultValue);
-						}catch (std::bad_variant_access const& ex){
-							throw std::runtime_error("Bad Variant Access: Type not bool");
-						}
-					}
-				},
-				[&](double* arg){
-					try{
-						*arg = node->get_parameter(mParamDescriptor).as_double();
-					}catch(rclcpp::exceptions::ParameterUninitializedException& e){
-						try{
-							*arg = std::get<double>(mDefaultValue);
-						}catch (std::bad_variant_access const& ex){
-							throw std::runtime_error("Bad Variant Access: Type not double");
-						}
-					}
-				},
-				[&](float* arg){
-					try{
-						*arg = static_cast<float>(node->get_parameter(mParamDescriptor).as_double());
-					}catch(rclcpp::exceptions::ParameterUninitializedException& e){
-						try{
-							*arg = std::get<float>(mDefaultValue);
-						}catch (std::bad_variant_access const& ex){
-							throw std::runtime_error("Bad Variant Access: Type not float");
-						}
-					}
-				}
-			}, mData);
-		}
+        void visit(rclcpp::Node* node) {
+            std::visit(overload{
+                               [&](int* arg) {
+                                   try {
+                                       *arg = static_cast<int>(node->get_parameter(mParamDescriptor).as_int());
+                                   } catch (rclcpp::exceptions::ParameterUninitializedException& e) {
+                                       try {
+                                           *arg = std::get<int>(mDefaultValue);
+                                       } catch (std::bad_variant_access const& ex) {
+                                           throw std::runtime_error("Bad Variant Access: Type not int");
+                                       }
+                                   }
+                               },
+                               [&](std::string* arg) {
+                                   try {
+                                       *arg = node->get_parameter(mParamDescriptor).as_string();
+                                   } catch (rclcpp::exceptions::ParameterUninitializedException& e) {
+                                       try {
+                                           *arg = std::get<std::string>(mDefaultValue);
+                                       } catch (std::bad_variant_access const& ex) {
+                                           throw std::runtime_error("Bad Variant Access: Type not std::string");
+                                       }
+                                   }
+                               },
+                               [&](bool* arg) {
+                                   try {
+                                       *arg = node->get_parameter(mParamDescriptor).as_bool();
+                                   } catch (rclcpp::exceptions::ParameterUninitializedException& e) {
+                                       try {
+                                           *arg = std::get<bool>(mDefaultValue);
+                                       } catch (std::bad_variant_access const& ex) {
+                                           throw std::runtime_error("Bad Variant Access: Type not bool");
+                                       }
+                                   }
+                               },
+                               [&](double* arg) {
+                                   try {
+                                       *arg = node->get_parameter(mParamDescriptor).as_double();
+                                   } catch (rclcpp::exceptions::ParameterUninitializedException& e) {
+                                       try {
+                                           *arg = std::get<double>(mDefaultValue);
+                                       } catch (std::bad_variant_access const& ex) {
+                                           throw std::runtime_error("Bad Variant Access: Type not double");
+                                       }
+                                   }
+                               },
+                               [&](float* arg) {
+                                   try {
+                                       *arg = static_cast<float>(node->get_parameter(mParamDescriptor).as_double());
+                                   } catch (rclcpp::exceptions::ParameterUninitializedException& e) {
+                                       try {
+                                           *arg = std::get<float>(mDefaultValue);
+                                       } catch (std::bad_variant_access const& ex) {
+                                           throw std::runtime_error("Bad Variant Access: Type not float");
+                                       }
+                                   }
+                               }},
+                       mData);
+        }
 
-		static inline auto declareParameters(rclcpp::Node* node, std::vector<ParameterWrapper>& params) -> void{
-			RCLCPP_INFO(rclcpp::get_logger("param_logger"), "Declaring %zu parameters...", params.size());
-			for(auto& param : params){
-				node->declare_parameter(param.mParamDescriptor, param.mType);
-				param.visit(node);
-			}
-		}
-	};
-};
+        static inline auto declareParameters(rclcpp::Node* node, std::vector<ParameterWrapper>& params) -> void {
+            RCLCPP_INFO(rclcpp::get_logger("param_logger"), "Declaring %zu parameters...", params.size());
+            for (auto& param: params) {
+                node->declare_parameter(param.mParamDescriptor, param.mType);
+                param.visit(node);
+            }
+        }
+    };
+}; // namespace mrover

--- a/parameter_utils/parameter.hpp
+++ b/parameter_utils/parameter.hpp
@@ -12,6 +12,9 @@ template<class... Ts> overload(Ts...) -> overload<Ts...>;
 
 
 namespace mrover {
+	template<typename T>
+	concept IsIntEnum = std::is_enum_v<T> && std::is_same_v<std::underlying_type_t<T>, int>;
+
 	class ParameterWrapper {
 	private:
 		static inline std::shared_ptr<rclcpp::ParameterCallbackHandle> cbHande;
@@ -34,6 +37,9 @@ namespace mrover {
 		ParameterWrapper(std::string paramDescriptor, double& variable, double defaultValue = 0.0) : mType{rclcpp::ParameterType::PARAMETER_DOUBLE}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue}{}
 
 		ParameterWrapper(std::string paramDescriptor, float& variable, float defaultValue = 0.0) : mType{rclcpp::ParameterType::PARAMETER_DOUBLE}, mParamDescriptor{std::move(paramDescriptor)}, mData{&variable}, mDefaultValue{defaultValue}{}
+
+        template<IsIntEnum T>
+        ParameterWrapper(std::string paramDescriptor, T& variable, T defaultValue) : mType{rclcpp::ParameterType::PARAMETER_INTEGER}, mParamDescriptor{std::move(paramDescriptor)}, mData{reinterpret_cast<int*>(&variable)}, mDefaultValue{static_cast<int>(defaultValue)} {}
 
 		void visit(rclcpp::Node* node){
 			std::visit(overload{

--- a/style.sh
+++ b/style.sh
@@ -55,7 +55,7 @@ readonly MYPY_PATH=$(find_executable mypy 1.11.2)
 
 # Add new directories with C++ code here:
 readonly CPP_FILES=(
-  ./{perception,lie,esw,simulator}/**/*.{cpp,hpp,h,cu,cuh}
+  ./{perception,lie,esw,simulator,parameter_utils}/**/*.{cpp,hpp,h,cu,cuh}
 )
 echo "Style checking C++ ..."
 "${CLANG_FORMAT_PATH}" "${CLANG_FORMAT_ARGS[@]}" -i "${CPP_FILES[@]}"


### PR DESCRIPTION
## Summary
Closes #(Your issue number here)

What features did you add, bugs did you fix, etc? 
Allows:
```
enum class MoteusAuxNumber : int {
    AUX1 = 1,
    AUX2 = 2,
};

MoteusAuxNumber auxNumber;

ParameterWrapper param("limit_switch_aux_number", auxNumber, MoteusAuxNumber::AUX1);
```

Also style fixes

### Did you add documentation to the wiki?
Yes/No (If not explain why not)

## How was this code tested? 

Tested to work with the enum above. Also made sure it does not compile with enum's without an underlying `int` type to reduce undefined behavior.

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
