### PR TITLE
reverse joint B direction

### DIFF
--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -28,7 +28,7 @@ arm_hw_bridge:
       min_position: -0.9
       max_position: 0.0
       gear_ratio: 1.0
-      is_inverted: false
+      is_inverted: true
       driver_voltage: 12.0
       motor_max_voltage: 12.0
       quad_present: false


### PR DESCRIPTION
## Summary
Closes N/A

What features did you add, bugs did you fix, etc? 
Reverse the direction of joint B so down on the left joystick is down on the rover. Verified the limit switch works correctly.

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested onboard the rover

### Did you test this in sim?
No

### Did you test this on the rover?
Yes

### Did you add unit tests? 
No