### PR TITLE
Service to control cam movement

### DIFF
--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -64,7 +64,7 @@ arm_hw_bridge:
     gripper:
       gear_ratio: 47.0
       is_inverted: true
-      driver_voltage: 10.5
+      driver_voltage: 12.0
       motor_max_voltage: 12.0
       quad_present: true
       quad_ratio: 1.0
@@ -78,6 +78,8 @@ arm_hw_bridge:
       limit_switch_0_active_high: false
       limit_switch_0_used_for_readjustment: true
       limit_switch_0_readjust_position: 0.0
+    cam_control_duration: 800 # milliseconds
+    cam_control_period: 50 # milliseconds
     cam:
       gear_ratio: 1.0
       is_inverted: false

--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -78,7 +78,7 @@ arm_hw_bridge:
       limit_switch_0_active_high: false
       limit_switch_0_used_for_readjustment: true
       limit_switch_0_readjust_position: 0.0
-    cam_control_duration: 800 # milliseconds
+    cam_control_duration: 950 # milliseconds
     cam_control_period: 50 # milliseconds
     cam:
       gear_ratio: 1.0

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -87,9 +87,9 @@ namespace mrover {
             mCamControlCallbackGroup = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
             mCamControlServer = create_service<srv::ControlCam>(
                     "cam_control",
-                    [this](srv::ControlCam::Request::SharedPtr const req,
-                           srv::ControlCam::Response::SharedPtr res) {
-                        camControlServiceCallback(req, std::move(res));
+                    [this](srv::ControlCam::Request::ConstSharedPtr const& req,
+                           srv::ControlCam::Response::SharedPtr const& res) {
+                        camControlServiceCallback(req, res);
                     },
                     rmw_qos_profile_services_default,
                     mCamControlCallbackGroup);
@@ -455,7 +455,7 @@ namespace mrover {
             camIn();
         }
 
-        auto camControlServiceCallback(srv::ControlCam::Request::SharedPtr const req, srv::ControlCam::Response::SharedPtr res) -> void {
+        auto camControlServiceCallback(srv::ControlCam::Request::ConstSharedPtr const& req, srv::ControlCam::Response::SharedPtr const& res) -> void {
             switch (req->action) {
                 case srv::ControlCam::Request::CAM_IN: {
                     camIn();

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -68,6 +68,7 @@ namespace mrover {
 
             mDeOffsetTimer = create_wall_timer(DE_OFFSET_TIMER_PERIOD, [this]() { updateDeOffsets(); });
 
+            int camControlDuration, camControlPeriod;
             std::vector<ParameterWrapper> parameters = {
                     {"joint_de_pitch_offset", mJointDePitchOffset.rep, 0.0},
                     {"joint_de_roll_offset", mJointDeRollOffset.rep, 0.0},
@@ -75,12 +76,6 @@ namespace mrover {
                     {"joint_de_pitch_min_position", mJointDePitchMinPosition.rep, -std::numeric_limits<float>::infinity()},
                     {"joint_de_roll_max_position", mJointDeRollMaxPosition.rep, std::numeric_limits<float>::infinity()},
                     {"joint_de_roll_min_position", mJointDeRollMinPosition.rep, -std::numeric_limits<float>::infinity()},
-            };
-            ParameterWrapper::declareParameters(shared_from_this().get(), parameters);
-
-
-            int camControlDuration, camControlPeriod;
-            std::vector<ParameterWrapper> parameters = {
                     {"cam_control_duration", camControlDuration, 0},
                     {"cam_control_period", camControlPeriod, 50},
             };

--- a/srv/ControlCam.srv
+++ b/srv/ControlCam.srv
@@ -1,0 +1,6 @@
+uint8 CAM_OUT=0
+uint8 CAM_IN=1
+uint8 CAM_PULSE=2
+uint8 action
+---
+bool success


### PR DESCRIPTION
## Summary
Cam can now be controlled by a service call (along with the normal /arm_throttle_cmd topic). 

What features did you add, bugs did you fix, etc? 
Cam out:
`ros2 service call /cam_control mrover/srv/ControlCam "{action: 0}"`
Cam in:
`ros2 service call /cam_control mrover/srv/ControlCam "{action: 1}"`
Cam pulse:
`ros2 service call /cam_control mrover/srv/ControlCam "{action: 2}"`

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested on rover

### Did you test this in sim? 
No

### Did you test this on the rover?
Yes

### Did you add unit tests? 
No
