### PR TITLE
removed django migration process from ansible build

### DIFF
--- a/ansible/roles/build/tasks/main.yml
+++ b/ansible/roles/build/tasks/main.yml
@@ -205,11 +205,3 @@
   command: ~/.bun/bin/bun install
   args:
     chdir: "{{ ansible_env.HOME }}/ros2_ws/src/mrover/teleoperation/basestation_gui/frontend"
-
-- name: Run Django migrations
-  shell: |
-    source ~/ros2_ws/src/mrover/venv/bin/activate
-    python teleoperation/basestation_gui/manage.py makemigrations
-    python teleoperation/basestation_gui/manage.py migrate
-  args:
-    chdir: "{{ ansible_env.HOME }}/ros2_ws/src/mrover"


### PR DESCRIPTION
removed the django migration step from ansible build.yml since it has been causing a lot of trouble for new members