### PR TITLE
add absolute encoders to de, enforce soft limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,10 +337,13 @@ if (EXISTS ${MROVER_EMBEDDED_ROOT_DIR} AND NOT APPLE)
     mrover_add_header_only_library(science esw/science)
     target_link_libraries(science INTERFACE can_device units)
 
+    mrover_add_header_only_library(abs esw/abs)
+    target_link_libraries(abs INTERFACE can_device units parameter_utils)
+
     macro(mrover_add_esw_bridge_node name sources)
         mrover_add_node(${name} ${sources})
         ament_target_dependencies(${name} rclcpp std_srvs dynamixel_sdk)
-        target_link_libraries(${name} can_device units motor science servo)
+        target_link_libraries(${name} can_device units motor science servo abs)
     endmacro()
 
     # esw hardware bridge nodes

--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -29,18 +29,16 @@ arm_hw_bridge:
     joint_b_mount_theta: 1.25499645 # radians
     joint_b_segment_offset_theta: 0.09384635 # radians
     joint_c_offset_theta: 3.5222 # radians
-    joint_c_max_position: 2.80 # radians
-    joint_c_min_position: -0.60 # radians
     joint_c:
       min_velocity: -0.377
       max_velocity: 0.377
-      min_position: -1.04719755 # -60deg
-      max_position: 3.05432619 # 175deg
+      min_position: -0.60 # radians
+      max_position: 2.80 # radians
       max_torque: 200.0
     # Offsets are subtracted from the absolute encoder readings for pitch and roll
     # In order to zero, move the joint to the zero position and read the unadjusted positions. These should be the set to the offsets
-    joint_de_pitch_offset: 0.130767 # radians
-    joint_de_roll_offset: 0.4271226 # radians
+    joint_de_pitch_offset: 0.00 #0.130767 # radians
+    joint_de_roll_offset: 0.00 #0.4271226 # radians
     joint_de_pitch_max_position: 1.39 # radians
     joint_de_pitch_min_position: -1.00 # radians
     joint_de_roll_max_position: 2.00 # radians

--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -3,8 +3,8 @@ arm_hw_bridge:
     joint_a:
       min_velocity: -0.08
       max_velocity: 0.08
-      min_position: 0.0
-      max_position: 0.35
+      #min_position: 0.0
+      #max_position: 0.35
       max_torque: 30.0
       limit_switch_0_present: true
       limit_switch_0_enabled: true
@@ -28,17 +28,17 @@ arm_hw_bridge:
     joint_b_offset: -0.07754990  # radians
     joint_b_mount_theta: 1.25499645 # radians
     joint_b_segment_offset_theta: 0.09384635 # radians
-    joint_c_offset_theta: 3.5222 # radians
+    joint_c_offset_theta: 0.059 # radians
     joint_c:
       min_velocity: -0.377
       max_velocity: 0.377
-      min_position: -0.60 # radians
+      min_position: -0.45 # radians
       max_position: 2.80 # radians
       max_torque: 200.0
     # Offsets are subtracted from the absolute encoder readings for pitch and roll
     # In order to zero, move the joint to the zero position and read the unadjusted positions. These should be the set to the offsets
-    joint_de_pitch_offset: 0.00 #0.130767 # radians
-    joint_de_roll_offset: 0.00 #0.4271226 # radians
+    joint_de_pitch_offset: -1.788 # radians
+    joint_de_roll_offset: -3.134 # radians
     joint_de_pitch_max_position: 1.39 # radians
     joint_de_pitch_min_position: -1.00 # radians
     joint_de_roll_max_position: 2.00 # radians
@@ -57,18 +57,3 @@ arm_hw_bridge:
       max_torque: 20.0
     pusher_throttle: 1.0
     pusher_wait_duration: 5.0
-    # TODO(eric): configure and enable DE limits
-#      limit_switch_0_present: true
-#      limit_switch_0_enabled: true
-#      limit_switch_0_limits_forward: true
-#      limit_switch_0_active_high: false
-#      limit_switch_0_used_for_readjustment: false
-#      limit_switch_0_aux_number: 1
-#      limit_switch_0_aux_pin: 0
-#      limit_switch_1_present: true
-#      limit_switch_1_enabled: true
-#      limit_switch_1_limits_forward: false
-#      limit_switch_1_active_high: false
-#      limit_switch_1_used_for_readjustment: false
-#      limit_switch_1_aux_number: 1
-#      limit_switch_1_aux_pin: 2

--- a/config/esw.yaml
+++ b/config/esw.yaml
@@ -58,6 +58,10 @@ can_bridge_1:
         id: 0x35
       pusher:
         id: 0x36
+      abs_de_pitch:
+        id: 0x37
+      abs_de_roll:
+        id: 0x38
 
 can_bridge_2:
   ros__parameters:

--- a/esw/abs/abs.hpp
+++ b/esw/abs/abs.hpp
@@ -14,13 +14,13 @@ namespace mrover {
 
         Radians mPosition{0.0f};
         RadiansPerSecond mVelocity{0.0f};
+
     public:
         AbsoluteEncoder(rclcpp::Node::SharedPtr node, std::string masterName, std::string deviceName, bool invert = false)
             : mNode{std::move(node)},
               mDevice{mNode, std::move(masterName), std::move(deviceName),
                       [this](CANMsg_t const& msg) -> void { processMessage(msg); }},
               mInvert{invert} {
-
         }
 
         void processMessage(CANMsg_t const& msg) {
@@ -43,7 +43,7 @@ namespace mrover {
             return mPosition;
         }
 
-        [[nodiscard]] auto getVelocity() const -> RadiansPerSecond{
+        [[nodiscard]] auto getVelocity() const -> RadiansPerSecond {
             return mVelocity;
         }
     };

--- a/esw/abs/abs.hpp
+++ b/esw/abs/abs.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "MRoverCAN.hpp"
+#include "can_device.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <units.hpp>
+
+namespace mrover {
+
+    class AbsoluteEncoder {
+        rclcpp::Node::SharedPtr mNode;
+        CANDevice mDevice;
+
+        Radians mPosition{0.0f};
+        RadiansPerSecond mVelocity{0.0f};
+    public:
+        AbsoluteEncoder(rclcpp::Node::SharedPtr node, std::string masterName, std::string deviceName)
+            : mNode{std::move(node)},
+              mDevice{mNode, std::move(masterName), std::move(deviceName),
+                      [this](CANMsg_t const& msg) -> void { processMessage(msg); }} {
+
+        }
+
+        void processMessage(CANMsg_t const& msg) {
+            std::visit([this](auto const& decoded) -> void {
+                using T = std::decay_t<decltype(decoded)>;
+
+                if constexpr (std::is_same_v<T, ABSEncoderState>) {
+                    // update local state
+                    mPosition = Radians{decoded.position};
+                    mVelocity = RadiansPerSecond{decoded.velocity};
+                } else {
+                    RCLCPP_WARN(mNode->get_logger(), "absolute encoder received unexpected message type %s", typeid(T).name());
+                }
+            },
+                       msg);
+        }
+
+        [[nodiscard]] auto getPosition() const -> Radians {
+            return mPosition;
+        }
+
+        [[nodiscard]] auto getVelocity() const -> RadiansPerSecond{
+            return mVelocity;
+        }
+    };
+
+} // namespace mrover

--- a/esw/abs/abs.hpp
+++ b/esw/abs/abs.hpp
@@ -10,14 +10,16 @@ namespace mrover {
     class AbsoluteEncoder {
         rclcpp::Node::SharedPtr mNode;
         CANDevice mDevice;
+        bool mInvert;
 
         Radians mPosition{0.0f};
         RadiansPerSecond mVelocity{0.0f};
     public:
-        AbsoluteEncoder(rclcpp::Node::SharedPtr node, std::string masterName, std::string deviceName)
+        AbsoluteEncoder(rclcpp::Node::SharedPtr node, std::string masterName, std::string deviceName, bool invert = false)
             : mNode{std::move(node)},
               mDevice{mNode, std::move(masterName), std::move(deviceName),
-                      [this](CANMsg_t const& msg) -> void { processMessage(msg); }} {
+                      [this](CANMsg_t const& msg) -> void { processMessage(msg); }},
+              mInvert{invert} {
 
         }
 
@@ -27,8 +29,9 @@ namespace mrover {
 
                 if constexpr (std::is_same_v<T, ABSEncoderState>) {
                     // update local state
-                    mPosition = Radians{decoded.position};
-                    mVelocity = RadiansPerSecond{decoded.velocity};
+                    float const sign = mInvert ? -1.0f : 1.0f;
+                    mPosition = Radians{decoded.position * sign};
+                    mVelocity = RadiansPerSecond{decoded.velocity * sign};
                 } else {
                     RCLCPP_WARN(mNode->get_logger(), "absolute encoder received unexpected message type %s", typeid(T).name());
                 }

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -21,9 +21,9 @@
 #include <mrover/msg/velocity.hpp>
 #include <mrover/srv/pusher.hpp>
 
+#include <abs.hpp>
 #include <brushed.hpp>
 #include <brushless.hpp>
-#include <abs.hpp>
 
 
 namespace mrover {
@@ -523,10 +523,10 @@ namespace mrover {
             mJointDEPitchRoll = {currentPitch, currentRoll};
 
             Vector2<Radians> motorPositionsRad = PITCH_ROLL_TO_01_SCALE * (PITCH_ROLL_TO_0_1 * mJointDEPitchRoll.value());
-            Revolutions const motor0Pos{motorPositionsRad[0]}; 
+            Revolutions const motor0Pos{motorPositionsRad[0]};
             Revolutions const motor1Pos{motorPositionsRad[1]};
 
-            mJointDE0->adjust(motor0Pos); 
+            mJointDE0->adjust(motor0Pos);
             mJointDE1->adjust(motor1Pos);
         }
 

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -2,6 +2,7 @@
 #include <future>
 #include <memory>
 #include <numbers>
+#include <rclcpp/logging.hpp>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,7 @@
 
 #include <brushed.hpp>
 #include <brushless.hpp>
+#include <abs.hpp>
 
 
 namespace mrover {
@@ -82,36 +84,16 @@ namespace mrover {
                     {"joint_b_mount_theta", mJointBMountTheta.rep, 0.0},
                     {"joint_b_segment_offset_theta", mJointBSegmentOffsetTheta.rep, 0.0},
                     {"joint_c_offset_theta", mJointCOffsetTheta.rep, 0.0},
-                    {"joint_c_max_position", mJointCMaxPosition.rep, 0.0},
-                    {"joint_c_min_position", mJointCMinPosition.rep, 0.0},
                     {"joint_de_pitch_offset", mJointDEPitchOffset.rep, 0.0},
                     {"joint_de_roll_offset", mJointDERollOffset.rep, 0.0},
                     {"joint_de_pitch_max_position", mJointDEPitchMaxPosition.rep, std::numeric_limits<float>::infinity()},
                     {"joint_de_pitch_min_position", mJointDEPitchMinPosition.rep, -std::numeric_limits<float>::infinity()},
                     {"joint_de_roll_max_position", mJointDERollMaxPosition.rep, std::numeric_limits<float>::infinity()},
-                    {"joint_de_roll_min_position", mJointDeRollMinPosition.rep, -std::numeric_limits<float>::infinity()},
+                    {"joint_de_roll_min_position", mJointDERollMinPosition.rep, -std::numeric_limits<float>::infinity()},
                     {"pusher_throttle", mPusherThrottle.rep, 0.0},
                     {"pusher_wait_duration", mPusherWaitDuration, 0.0},
             };
             ParameterWrapper::declareParameters(this, parameters);
-
-            BrushlessController<Radians>::Options jointDE0Opts{
-                    .query_abs_position = true,
-                    .use_abs_position = true,
-                    .abs_position_offset = mJointDERollOffset.get(),
-                    .query_abs_velocity = true,
-                    .use_abs_velocity = true,
-                    .abs_units_multiplier = 2.0 * M_PI // output encoder is raw/cpr, scale to rads
-            };
-
-            BrushlessController<Radians>::Options jointDE1Opts{
-                    .query_abs_position = true,
-                    .use_abs_position = true,
-                    .abs_position_offset = mJointDEPitchOffset.get(),
-                    .query_abs_velocity = true,
-                    .use_abs_velocity = true,
-                    .abs_units_multiplier = 2.0 * M_PI // output encoder is raw/cpr, scale to rads
-            };
 
             BrushlessController<Radians>::Options jointCOpts{
                     .query_abs_position = true,
@@ -125,10 +107,12 @@ namespace mrover {
             mJointA = std::make_shared<BrushlessController<Meters>>(shared_from_this(), "jetson", "joint_a");
             mJointB = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "joint_b");
             mJointC = std::make_shared<BrushlessController<Radians>>(shared_from_this(), "jetson", "joint_c", jointCOpts);
-            mJointDE0 = std::make_shared<BrushlessController<Radians>>(shared_from_this(), "jetson", "joint_de_0", jointDE0Opts);
-            mJointDE1 = std::make_shared<BrushlessController<Radians>>(shared_from_this(), "jetson", "joint_de_1", jointDE1Opts);
+            mJointDE0 = std::make_shared<BrushlessController<Revolutions>>(shared_from_this(), "jetson", "joint_de_0");
+            mJointDE1 = std::make_shared<BrushlessController<Revolutions>>(shared_from_this(), "jetson", "joint_de_1");
             mGripper = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "gripper");
             mPusher = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "pusher");
+            mAbsDEPitch = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_pitch");
+            mAbsDERoll = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_roll");
 
             mArmThrottleSub = create_subscription<msg::Throttle>("arm_thr_cmd", 1, [this](msg::Throttle::ConstSharedPtr const& msg) -> void { processThrottleCmd(msg); });
             mArmVelocitySub = create_subscription<msg::Velocity>("arm_vel_cmd", 1, [this](msg::Velocity::ConstSharedPtr const& msg) -> void { processVelocityCmd(msg); });
@@ -183,6 +167,8 @@ namespace mrover {
             mControllerState.velocities.resize(mJointNames.size());
             mControllerState.currents.resize(mJointNames.size());
             mControllerState.limits_hit.resize(mJointNames.size());
+
+            RCLCPP_INFO(get_logger(), "Arm HW Bridge Initialized");
         }
 
     private:
@@ -195,10 +181,12 @@ namespace mrover {
         std::shared_ptr<BrushlessController<Meters>> mJointA;
         std::shared_ptr<BrushedController<Meters>> mJointB;
         std::shared_ptr<BrushlessController<Radians>> mJointC;
-        std::shared_ptr<BrushlessController<Radians>> mJointDE0;
-        std::shared_ptr<BrushlessController<Radians>> mJointDE1;
+        std::shared_ptr<BrushlessController<Revolutions>> mJointDE0;
+        std::shared_ptr<BrushlessController<Revolutions>> mJointDE1;
         std::shared_ptr<BrushedController<Meters>> mGripper;
         std::shared_ptr<BrushedController<Meters>> mPusher;
+        std::shared_ptr<AbsoluteEncoder> mAbsDEPitch;
+        std::shared_ptr<AbsoluteEncoder> mAbsDERoll;
 
         rclcpp::CallbackGroup::SharedPtr mCbGroup;
         PusherState mPusherState = PusherState::IDLE;
@@ -210,7 +198,7 @@ namespace mrover {
         rclcpp::Service<srv::Pusher>::SharedPtr mPusherService;
 
         Meters mJointBSegmentLength, mJointBActuatorLength, mJointBMountLength;
-        Radians mJointBMountTheta, mJointBSegmentOffsetTheta, mJointBOffset, mJointCOffsetTheta, mJointCMaxPosition, mJointCMinPosition;
+        Radians mJointBMountTheta, mJointBSegmentOffsetTheta, mJointBOffset, mJointCOffsetTheta;
 
         Percent mPusherThrottle;
         float mPusherWaitDuration{}, mPusherWaitCycles{};
@@ -219,7 +207,7 @@ namespace mrover {
         std::optional<Vector2<Radians>> mJointDEPitchRoll; // position after offset is applied (raw - offset)
 
         Radians mJointDEPitchMaxPosition, mJointDEPitchMinPosition;
-        Radians mJointDERollMaxPosition, mJointDeRollMinPosition;
+        Radians mJointDERollMaxPosition, mJointDERollMinPosition;
 
         std::unordered_map<std::string_view, rclcpp::Time> mLastCommandTime;
         std::chrono::milliseconds const mProbeInterval{100};
@@ -357,19 +345,9 @@ namespace mrover {
                     case 'j' + 'b':
                         mJointB->setDesiredThrottle(throttle);
                         break;
-                    case 'j' + 'c': {
-                        auto thr = throttle;
-                        auto const pos = Radians{mJointC->getPosition()};
-                        if (pos >= mJointCMaxPosition) {
-                            RCLCPP_INFO(get_logger(), "Joint C max position limit hit!");
-                            thr = std::min(Dimensionless{0}, throttle);
-                        } else if (pos <= mJointCMinPosition) {
-                            RCLCPP_INFO(get_logger(), "Joint C min position limit hit!");
-                            thr = std::max(Dimensionless{0}, throttle);
-                        }
-                        mJointC->setDesiredThrottle(thr);
+                    case 'j' + 'c':
+                        mJointC->setDesiredThrottle(throttle);
                         break;
-                    }
                     case 'g' + 'r':
                         mGripper->setDesiredThrottle(throttle);
                         break;
@@ -393,7 +371,7 @@ namespace mrover {
                         jointDePitchThrottle = Dimensionless{0};
                     }
                     if ((*jointDeRollThrottle > Dimensionless{0} && (*mJointDEPitchRoll)[1] >= mJointDERollMaxPosition) ||
-                        (*jointDeRollThrottle < Dimensionless{0} && (*mJointDEPitchRoll)[1] <= mJointDeRollMinPosition)) {
+                        (*jointDeRollThrottle < Dimensionless{0} && (*mJointDEPitchRoll)[1] <= mJointDERollMinPosition)) {
                         RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
                         jointDeRollThrottle = Dimensionless{0};
                     }
@@ -415,7 +393,7 @@ namespace mrover {
                 return;
             }
 
-            std::optional<RadiansPerSecond> jointDePitchVelocity, jointDeRollVelocity;
+            std::optional<RadiansPerSecond> jointDEPitchVelocity, jointDeRollVelocity;
 
             for (std::size_t i = 0; i < msg->names.size(); ++i) {
                 std::string const& name = msg->names[i];
@@ -425,7 +403,7 @@ namespace mrover {
                 // Silly little thing to save some speed. Could easily just do the straight up string comparision
                 switch (name.front() + name.back()) {
                     case 'j' + 'h':
-                        jointDePitchVelocity = RadiansPerSecond{velocity};
+                        jointDEPitchVelocity = RadiansPerSecond{velocity};
                         break;
                     case 'j' + 'l':
                         jointDeRollVelocity = RadiansPerSecond{velocity};
@@ -440,40 +418,30 @@ namespace mrover {
                         mJointB->setDesiredVelocity(target_vel);
                         break;
                     }
-                    case 'j' + 'c': {
-                        auto vel = velocity;
-                        auto const pos = Radians{mJointC->getPosition()};
-                        if (pos >= mJointCMaxPosition) {
-                            RCLCPP_INFO(get_logger(), "Joint C max position limit hit!");
-                            vel = std::min(0.0f, vel);
-                        } else if (pos <= mJointCMinPosition) {
-                            RCLCPP_INFO(get_logger(), "Joint C min position limit hit!");
-                            vel = std::max(0.0f, vel);
-                        }
-                        mJointC->setDesiredVelocity(RadiansPerSecond{vel});
+                    case 'j' + 'c':
+                        mJointC->setDesiredVelocity(RadiansPerSecond{velocity});
                         break;
-                    }
                     case 'g' + 'r':
                         mGripper->setDesiredVelocity(MetersPerSecond{velocity});
                         break;
                 }
             }
 
-            if (jointDePitchVelocity.has_value() || jointDeRollVelocity.has_value()) {
-                if (!jointDePitchVelocity.has_value()) {
-                    jointDePitchVelocity = RadiansPerSecond{0};
+            if (jointDEPitchVelocity.has_value() || jointDeRollVelocity.has_value()) {
+                if (!jointDEPitchVelocity.has_value()) {
+                    jointDEPitchVelocity = RadiansPerSecond{0};
                 } else if (!jointDeRollVelocity.has_value()) {
                     jointDeRollVelocity = RadiansPerSecond{0};
                 }
 
                 if (mJointDEPitchRoll.has_value()) {
-                    if ((*jointDePitchVelocity > RadiansPerSecond{0} && (*mJointDEPitchRoll)[0] >= mJointDEPitchMaxPosition) ||
-                        (*jointDePitchVelocity < RadiansPerSecond{0} && (*mJointDEPitchRoll)[0] <= mJointDEPitchMinPosition)) {
+                    if ((*jointDEPitchVelocity > RadiansPerSecond{0} && (*mJointDEPitchRoll)[0] >= mJointDEPitchMaxPosition) ||
+                        (*jointDEPitchVelocity < RadiansPerSecond{0} && (*mJointDEPitchRoll)[0] <= mJointDEPitchMinPosition)) {
                         RCLCPP_INFO(get_logger(), "Joint DE Pitch limit hit!");
-                        jointDePitchVelocity = RadiansPerSecond{0};
+                        jointDEPitchVelocity = RadiansPerSecond{0};
                     }
                     if ((*jointDeRollVelocity > RadiansPerSecond{0} && (*mJointDEPitchRoll)[1] >= mJointDERollMaxPosition) ||
-                        (*jointDeRollVelocity < RadiansPerSecond{0} && (*mJointDEPitchRoll)[1] <= mJointDeRollMinPosition)) {
+                        (*jointDeRollVelocity < RadiansPerSecond{0} && (*mJointDEPitchRoll)[1] <= mJointDERollMinPosition)) {
                         RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
                         jointDeRollVelocity = RadiansPerSecond{0};
                     }
@@ -481,11 +449,11 @@ namespace mrover {
                     RCLCPP_WARN(get_logger(), "Commanding Joint DE velocity with no position readings! No limits will be enforced");
                 }
 
-                Vector2<RadiansPerSecond> const pitchRollVelocities{jointDePitchVelocity.value(), jointDeRollVelocity.value()};
+                Vector2<RadiansPerSecond> const pitchRollVelocities{jointDEPitchVelocity.value(), jointDeRollVelocity.value()};
                 Vector2<RadiansPerSecond> const motorVelocities = PITCH_ROLL_TO_01_SCALE * PITCH_ROLL_TO_0_1 * pitchRollVelocities;
 
-                mJointDE0->setDesiredVelocity(motorVelocities[0]);
-                mJointDE1->setDesiredVelocity(motorVelocities[1]);
+                mJointDE0->setDesiredVelocity(RevolutionsPerSecond{motorVelocities[0]});
+                mJointDE1->setDesiredVelocity(RevolutionsPerSecond{motorVelocities[1]});
             }
         }
 
@@ -518,62 +486,57 @@ namespace mrover {
                         mJointB->setDesiredPosition(target_meters);
                         break;
                     }
-                    case 'j' + 'c': {
-                        auto pos = position;
-                        auto const absPos = Radians{mJointC->getPosition()};
-                        if (absPos >= mJointCMaxPosition) {
-                            RCLCPP_INFO(get_logger(), "Joint C max position limit hit!");
-                            pos = mJointCMaxPosition.get();
-                        } else if (absPos <= mJointCMinPosition) {
-                            RCLCPP_INFO(get_logger(), "Joint C min position limit hit!");
-                            pos = mJointCMinPosition.get();
-                        }
-                        mJointC->setDesiredPosition(Radians{pos});
+                    case 'j' + 'c':
+                        mJointC->setDesiredPosition(Radians{position});
                         break;
-                    }
                     case 'g' + 'r':
                         mGripper->setDesiredPosition(Meters{position});
                         break;
                 }
             }
-            // TODO(eric) something is off here
-            // if (jointDEPitchPosition.has_value() || jointDERollPosition.has_value()) {
-            //     if (!mJointDEPitchRoll.has_value()) {
-            //         RCLCPP_WARN(get_logger(), "Commanding Joint DE position with no position readings! Not commanding position");
-            //         return;
-            //     }
-            //
-            //     if (!jointDEPitchPosition.has_value()) {
-            //         jointDEPitchPosition = (*mJointDEPitchRoll)[0];
-            //     } else if (!jointDERollPosition.has_value()) {
-            //         jointDERollPosition = (*mJointDEPitchRoll)[1];
-            //     }
-            //
-            //     if ((*jointDEPitchPosition >= mJointDePitchMaxPosition) || (*jointDEPitchPosition <= mJointDePitchMinPosition)) {
-            //         RCLCPP_INFO(get_logger(), "Joint DE Pitch limit hit!");
-            //         jointDEPitchPosition = (*mJointDEPitchRoll)[0];
-            //     }
-            //     if ((*jointDERollPosition >= mJointDERollMaxPosition) || (*jointDERollPosition <= mJointDeRollMinPosition)) {
-            //         RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
-            //         jointDERollPosition = (*mJointDEPitchRoll)[1];
-            //     }
-            //
-            //     Vector2<Radians> const pitchRollPositions{jointDEPitchPosition.value(), jointDERollPosition.value()};
-            //     Vector2<Radians> motorPositions = PITCH_ROLL_TO_01_SCALE * PITCH_ROLL_TO_0_1 * pitchRollPositions;
-            //
-            //     mJointDE0->setDesiredPosition(motorPositions[1]);
-            //     mJointDE1->setDesiredPosition(motorPositions[0]);
-            // }
+
+            if (jointDEPitchPosition.has_value() || jointDERollPosition.has_value()) {
+                if (!mJointDEPitchRoll.has_value()) {
+                    RCLCPP_WARN(get_logger(), "Commanding Joint DE position with no position readings! Not commanding position");
+                    return;
+                }
+
+                if (!jointDEPitchPosition.has_value()) {
+                    jointDEPitchPosition = (*mJointDEPitchRoll)[0];
+                } else if (!jointDERollPosition.has_value()) {
+                    jointDERollPosition = (*mJointDEPitchRoll)[1];
+                }
+
+                if ((*jointDEPitchPosition >= mJointDEPitchMaxPosition) || (*jointDEPitchPosition <= mJointDEPitchMinPosition)) {
+                    RCLCPP_INFO(get_logger(), "Joint DE Pitch limit hit!");
+                    jointDEPitchPosition = (*mJointDEPitchRoll)[0];
+                }
+                if ((*jointDERollPosition >= mJointDERollMaxPosition) || (*jointDERollPosition <= mJointDERollMinPosition)) {
+                    RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
+                    jointDERollPosition = (*mJointDEPitchRoll)[1];
+                }
+
+                Vector2<Radians> const pitchRollPositions{jointDEPitchPosition.value(), jointDERollPosition.value()};
+                Vector2<Radians> motorPositions = PITCH_ROLL_TO_01_SCALE * PITCH_ROLL_TO_0_1 * pitchRollPositions;
+
+                mJointDE0->setDesiredPosition(Revolutions{motorPositions[0]});
+                mJointDE1->setDesiredPosition(Revolutions{motorPositions[1]});
+            }
         }
 
-        auto updateAbsoluteOffsets() const -> void {
-            mJointC->adjust(Radians{mJointC->getPosition()});
+        auto updateAbsoluteOffsets() -> void {
+            mJointC->adjust(mJointCOffsetTheta);
 
-            if (!mJointDEPitchRoll) return;
+            Radians const currentPitch = mAbsDEPitch->getPosition() - mJointDEPitchOffset;
+            Radians const currentRoll = mAbsDERoll->getPosition() - mJointDERollOffset;
+            mJointDEPitchRoll = {currentPitch, currentRoll};
 
-            Vector2<Radians> motorPositions = PITCH_ROLL_TO_01_SCALE * PITCH_ROLL_TO_0_1 * mJointDEPitchRoll.value();
-            mJointDE0->adjust(motorPositions[1]); // DE0: Roll
-            mJointDE1->adjust(motorPositions[0]); // DE1: Pitch
+            Vector2<Radians> motorPositionsRad = PITCH_ROLL_TO_01_SCALE * (PITCH_ROLL_TO_0_1 * mJointDEPitchRoll.value());
+            Revolutions const motor0Pos{motorPositionsRad[0]}; 
+            Revolutions const motor1Pos{motorPositionsRad[1]};
+
+            mJointDE0->adjust(motor0Pos); 
+            mJointDE1->adjust(motor1Pos);
         }
 
         auto handlePusherService(srv::Pusher::Request::ConstSharedPtr const& req, srv::Pusher::Response::SharedPtr const& res) -> void {
@@ -647,9 +610,15 @@ namespace mrover {
         auto publishDataCallback() -> void {
             mControllerState.header.stamp = now();
 
-            auto const pitchWrapped = wrapAngle(mJointDE1->getPosition());
-            auto const rollWrapped = -1 * wrapAngle(mJointDE0->getPosition());
-            mJointDEPitchRoll = {pitchWrapped, rollWrapped};
+            Radians const pitch = mAbsDEPitch->getPosition() - mJointDEPitchOffset;
+            Radians const roll = mAbsDERoll->getPosition() - mJointDERollOffset;
+            mJointDEPitchRoll = {pitch, roll};
+            // auto const pitchWrapped = wrapAngle(mJointDE1->getPosition());
+            // auto const rollWrapped = -1 * wrapAngle(mJointDE0->getPosition());
+            // mJointDEPitchRoll = {pitchWrapped, rollWrapped};
+
+            mJointDE1->setExternalSoftLimits(pitch >= mJointDEPitchMaxPosition, pitch <= mJointDEPitchMinPosition);
+            mJointDE0->setExternalSoftLimits(roll >= mJointDERollMaxPosition, roll <= mJointDERollMinPosition);
 
             for (std::size_t i = 0; i < mJointNames.size(); ++i) {
                 std::string_view const name = mJointNames[i];
@@ -659,8 +628,8 @@ namespace mrover {
                         mControllerState.names[i] = name;
                         mControllerState.states[i] = mJointDE1->getState();
                         mControllerState.errors[i] = mJointDE1->getError();
-                        mControllerState.positions[i] = pitchWrapped;
-                        mControllerState.velocities[i] = {RadiansPerSecond{mJointDE1->getVelocity()}.get()};
+                        mControllerState.positions[i] = pitch.get();
+                        mControllerState.velocities[i] = mAbsDEPitch->getVelocity().get(); //{RadiansPerSecond{mJointDE1->getVelocity()}.get()};
                         mControllerState.currents[i] = mJointDE1->getCurrent();
                         mControllerState.limits_hit[i] = mJointDE1->getLimitsHitBits();
                         break;
@@ -668,8 +637,8 @@ namespace mrover {
                         mControllerState.names[i] = name;
                         mControllerState.states[i] = mJointDE0->getState();
                         mControllerState.errors[i] = mJointDE0->getError();
-                        mControllerState.positions[i] = rollWrapped;
-                        mControllerState.velocities[i] = {RadiansPerSecond{mJointDE0->getVelocity()}.get()};
+                        mControllerState.positions[i] = roll.get();
+                        mControllerState.velocities[i] = mAbsDERoll->getVelocity().get(); // {RadiansPerSecond{mJointDE0->getVelocity()}.get()};
                         mControllerState.currents[i] = mJointDE0->getCurrent();
                         mControllerState.limits_hit[i] = mJointDE0->getLimitsHitBits();
                         break;

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -45,7 +45,7 @@ namespace mrover {
     // Maps pitch and roll values to the DE0 and DE1 motors outputs
     // For example when only pitching the motor, both controllers should be moving in the same direction
     // When rolling, the controllers should move in opposite directions
-    auto static const PITCH_ROLL_TO_0_1 = (Matrix2<Dimensionless>{} << -1, -1, -1, 1).finished();
+    auto static const PITCH_ROLL_TO_0_1 = (Matrix2<Dimensionless>{} << 1, -1, 1, 1).finished();
     Dimensionless static constexpr PITCH_ROLL_TO_01_SCALE{40};
 
     auto static constexpr PROBE_INTERVAL_MS = 100;
@@ -111,8 +111,8 @@ namespace mrover {
             mJointDE1 = std::make_shared<BrushlessController<Revolutions>>(shared_from_this(), "jetson", "joint_de_1");
             mGripper = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "gripper");
             mPusher = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "pusher");
-            mAbsDEPitch = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_pitch");
-            mAbsDERoll = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_roll");
+            mAbsDEPitch = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_pitch", true);
+            mAbsDERoll = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_roll", true);
 
             mArmThrottleSub = create_subscription<msg::Throttle>("arm_thr_cmd", 1, [this](msg::Throttle::ConstSharedPtr const& msg) -> void { processThrottleCmd(msg); });
             mArmVelocitySub = create_subscription<msg::Velocity>("arm_vel_cmd", 1, [this](msg::Velocity::ConstSharedPtr const& msg) -> void { processVelocityCmd(msg); });
@@ -235,13 +235,10 @@ namespace mrover {
 
             if (brushless_meters && *brushless_meters) {
                 (*brushless_meters)->sendQuery();
-                (*brushless_meters)->getPressedLimitSwitchInfo();
             } else if (brushless_revs && *brushless_revs) {
                 (*brushless_revs)->sendQuery();
-                (*brushless_revs)->getPressedLimitSwitchInfo();
             } else if (brushless_rads && *brushless_rads) {
                 (*brushless_rads)->sendQuery();
-                (*brushless_rads)->getPressedLimitSwitchInfo();
             }
         }
 
@@ -367,12 +364,10 @@ namespace mrover {
                 if (mJointDEPitchRoll.has_value()) {
                     if ((*jointDePitchThrottle > Dimensionless{0} && (*mJointDEPitchRoll)[0] >= mJointDEPitchMaxPosition) ||
                         (*jointDePitchThrottle < Dimensionless{0} && (*mJointDEPitchRoll)[0] <= mJointDEPitchMinPosition)) {
-                        RCLCPP_INFO(get_logger(), "Joint DE Pitch limit hit!");
                         jointDePitchThrottle = Dimensionless{0};
                     }
                     if ((*jointDeRollThrottle > Dimensionless{0} && (*mJointDEPitchRoll)[1] >= mJointDERollMaxPosition) ||
                         (*jointDeRollThrottle < Dimensionless{0} && (*mJointDEPitchRoll)[1] <= mJointDERollMinPosition)) {
-                        RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
                         jointDeRollThrottle = Dimensionless{0};
                     }
                 } else {
@@ -437,12 +432,10 @@ namespace mrover {
                 if (mJointDEPitchRoll.has_value()) {
                     if ((*jointDEPitchVelocity > RadiansPerSecond{0} && (*mJointDEPitchRoll)[0] >= mJointDEPitchMaxPosition) ||
                         (*jointDEPitchVelocity < RadiansPerSecond{0} && (*mJointDEPitchRoll)[0] <= mJointDEPitchMinPosition)) {
-                        RCLCPP_INFO(get_logger(), "Joint DE Pitch limit hit!");
                         jointDEPitchVelocity = RadiansPerSecond{0};
                     }
                     if ((*jointDeRollVelocity > RadiansPerSecond{0} && (*mJointDEPitchRoll)[1] >= mJointDERollMaxPosition) ||
                         (*jointDeRollVelocity < RadiansPerSecond{0} && (*mJointDEPitchRoll)[1] <= mJointDERollMinPosition)) {
-                        RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
                         jointDeRollVelocity = RadiansPerSecond{0};
                     }
                 } else {
@@ -508,11 +501,9 @@ namespace mrover {
                 }
 
                 if ((*jointDEPitchPosition >= mJointDEPitchMaxPosition) || (*jointDEPitchPosition <= mJointDEPitchMinPosition)) {
-                    RCLCPP_INFO(get_logger(), "Joint DE Pitch limit hit!");
                     jointDEPitchPosition = (*mJointDEPitchRoll)[0];
                 }
                 if ((*jointDERollPosition >= mJointDERollMaxPosition) || (*jointDERollPosition <= mJointDERollMinPosition)) {
-                    RCLCPP_INFO(get_logger(), "Joint DE Roll limit hit!");
                     jointDERollPosition = (*mJointDEPitchRoll)[1];
                 }
 

--- a/esw/motor/brushless.hpp
+++ b/esw/motor/brushless.hpp
@@ -131,6 +131,8 @@ namespace mrover {
         std::optional<moteus::Controller> mMoteus;
         std::int8_t mMoteusAux1Info{}, mMoteusAux2Info{};
         bool mHasLimit{};
+        bool mExtSoftFwd{false};
+        bool mExtSoftBwd{false};
 
     public:
         BrushlessController(rclcpp::Node::SharedPtr node, std::string masterName, std::string controllerName, Options options = Options{})
@@ -329,19 +331,34 @@ namespace mrover {
             mDevice.publishMessage(brakeFrame);
         }
 
+        auto setExternalSoftLimits(bool fwd, bool bwd) -> void {
+            mExtSoftFwd = fwd;
+            mExtSoftBwd = bwd;
+        }
+
         auto getPressedLimitSwitchInfo() -> MoteusLimitSwitchInfo {
             MoteusLimitSwitchInfo result{};
+            bool const internalFwd = (mPosition >= mMaxPosition.get());
+            bool const internalBwd = (mPosition <= mMinPosition.get());
+
             for (std::size_t i = 0; i < MAX_NUM_LIMIT_SWITCHES; ++i) {
+                bool hardwareHit = false;
                 if (mLimitSwitchesInfo[i].present && mLimitSwitchesInfo[i].enabled) {
                     std::uint8_t const auxInfo = (mLimitSwitchesInfo[i].auxNumber == MoteusAuxNumber::AUX1) ? mMoteusAux1Info : mMoteusAux2Info;
                     bool gpioState = auxInfo & (1 << static_cast<std::size_t>(mLimitSwitchesInfo[i].auxPin));
-
-                    // Assign to Base m_limit_hit
-                    mLimitHit[i] = (gpioState == mLimitSwitchesInfo[i].activeHigh);
+                    hardwareHit = (gpioState == mLimitSwitchesInfo[i].activeHigh);
                 }
+
+                if (mLimitSwitchesInfo[i].limitsForward) {
+                    mLimitHit[i] = hardwareHit || internalFwd || mExtSoftFwd;
+                } else {
+                    mLimitHit[i] = hardwareHit || internalBwd || mExtSoftBwd;
+                }
+
                 result.isForwardPressed = (mLimitHit[i] && mLimitSwitchesInfo[i].limitsForward) || result.isForwardPressed;
                 result.isBackwardPressed = (mLimitHit[i] && !mLimitSwitchesInfo[i].limitsForward) || result.isBackwardPressed;
-                if (mLimitSwitchesInfo[i].usedForReadjustment && mLimitHit[i]) {
+
+                if (mLimitSwitchesInfo[i].usedForReadjustment && hardwareHit) {
                     adjust(mLimitSwitchesInfo[i].readjustPosition);
                 }
             }

--- a/esw/motor/brushless.hpp
+++ b/esw/motor/brushless.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include <limits>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
@@ -121,8 +122,8 @@ namespace mrover {
         int mAbsVelExtraIndex = -1;
         OutputVelocity mMinVelocity = OutputVelocity{-1.0};
         OutputVelocity mMaxVelocity = OutputVelocity{1.0};
-        OutputPosition mMinPosition = OutputPosition{-1.0};
-        OutputPosition mMaxPosition = OutputPosition{1.0};
+        OutputPosition mMinPosition = OutputPosition{-std::numeric_limits<double>::infinity()};
+        OutputPosition mMaxPosition = OutputPosition{std::numeric_limits<double>::infinity()};
         double mMaxTorque = 0.3;
         double mWatchdogTimeout = 0.25;
         double mCurrentEffort{std::numeric_limits<double>::quiet_NaN()};
@@ -131,6 +132,8 @@ namespace mrover {
         std::optional<moteus::Controller> mMoteus;
         std::int8_t mMoteusAux1Info{}, mMoteusAux2Info{};
         bool mHasLimit{};
+        bool mIsFwdLimitHit{false};
+        bool mIsBwdLimitHit{false};
         bool mExtSoftFwd{false};
         bool mExtSoftBwd{false};
 
@@ -143,8 +146,8 @@ namespace mrover {
             std::vector<ParameterWrapper> parameters = {
                     {std::format("{}.min_velocity", mControllerName), minVelocity, -1.0},
                     {std::format("{}.max_velocity", mControllerName), maxVelocity, 1.0},
-                    {std::format("{}.min_position", mControllerName), minPosition, -1.0},
-                    {std::format("{}.max_position", mControllerName), maxPosition, 1.0},
+                    {std::format("{}.min_position", mControllerName), minPosition, -std::numeric_limits<double>::infinity()},
+                    {std::format("{}.max_position", mControllerName), maxPosition, std::numeric_limits<double>::infinity()},
                     {std::format("{}.max_torque", mControllerName), mMaxTorque, 0.3},
                     {std::format("{}.watchdog_timeout", mControllerName), mWatchdogTimeout, 0.25},
             };
@@ -216,15 +219,11 @@ namespace mrover {
 
         auto setDesiredVelocity(OutputVelocity velocity) -> void {
             sendQuery();
-            // Only check for limit switches if at least one limit switch exists and is enabled
-            if (mHasLimit) {
 
-                if (auto [isFwdPressed, isBwdPressed] = getPressedLimitSwitchInfo();
-                    (velocity > OutputVelocity{0} && isFwdPressed) ||
-                    (velocity < OutputVelocity{0} && isBwdPressed)) {
-                    setBrake();
-                    return;
-                }
+            if ((velocity > OutputVelocity{0} && mIsFwdLimitHit) ||
+                (velocity < OutputVelocity{0} && mIsBwdLimitHit)) {
+                setBrake();
+                return;
             }
 
             velocity = std::clamp(velocity, mMinVelocity, mMaxVelocity);
@@ -252,14 +251,11 @@ namespace mrover {
 
         auto setDesiredPosition(OutputPosition position) -> void {
             sendQuery();
-            // Only check for limit switches if at least one limit switch exists and is enabled
-            if (mHasLimit) {
-                if (auto [isFwdPressed, isBwdPressed] = getPressedLimitSwitchInfo();
-                    (mPosition < position.get() && isFwdPressed) ||
-                    (mPosition > position.get() && isBwdPressed)) {
-                    setBrake();
-                    return;
-                }
+
+            if ((mPosition < position.get() && mIsFwdLimitHit) ||
+                (mPosition > position.get() && mIsBwdLimitHit)) {
+                setBrake();
+                return;
             }
 
             position = std::clamp(position, mMinPosition, mMaxPosition);
@@ -307,6 +303,8 @@ namespace mrover {
                     mMoteusAux1Info = result.aux1_gpio;
                     mMoteusAux2Info = result.aux2_gpio;
 
+                    updateLimitSwitchInfo();
+
                     if (result.mode == moteus::Mode::kPositionTimeout) {
                         setStop();
                         RCLCPP_WARN_STREAM(mNode->get_logger(), "Position timeout hit on " << this->mControllerName);
@@ -336,33 +334,54 @@ namespace mrover {
             mExtSoftBwd = bwd;
         }
 
-        auto getPressedLimitSwitchInfo() -> MoteusLimitSwitchInfo {
-            MoteusLimitSwitchInfo result{};
+        auto updateLimitSwitchInfo() -> void {
             bool const internalFwd = (mPosition >= mMaxPosition.get());
             bool const internalBwd = (mPosition <= mMinPosition.get());
 
+            bool fwdPressed = internalFwd || mExtSoftFwd;
+            bool bwdPressed = internalBwd || mExtSoftBwd;
+
+            bool fwdMapped = false;
+            bool bwdMapped = false;
+
             for (std::size_t i = 0; i < MAX_NUM_LIMIT_SWITCHES; ++i) {
-                bool hardwareHit = false;
                 if (mLimitSwitchesInfo[i].present && mLimitSwitchesInfo[i].enabled) {
                     std::uint8_t const auxInfo = (mLimitSwitchesInfo[i].auxNumber == MoteusAuxNumber::AUX1) ? mMoteusAux1Info : mMoteusAux2Info;
                     bool gpioState = auxInfo & (1 << static_cast<std::size_t>(mLimitSwitchesInfo[i].auxPin));
-                    hardwareHit = (gpioState == mLimitSwitchesInfo[i].activeHigh);
-                }
+                    bool hardwareHit = (gpioState == mLimitSwitchesInfo[i].activeHigh);
 
-                if (mLimitSwitchesInfo[i].limitsForward) {
-                    mLimitHit[i] = hardwareHit || internalFwd || mExtSoftFwd;
+                    if (mLimitSwitchesInfo[i].limitsForward) {
+                        mLimitHit[i] = hardwareHit || fwdPressed;
+                        fwdPressed = fwdPressed || hardwareHit;
+                        fwdMapped = true;
+                    } else {
+                        mLimitHit[i] = hardwareHit || bwdPressed;
+                        bwdPressed = bwdPressed || hardwareHit;
+                        bwdMapped = true;
+                    }
+
+                    if (mLimitSwitchesInfo[i].usedForReadjustment && hardwareHit) {
+                        adjust(mLimitSwitchesInfo[i].readjustPosition);
+                    }
                 } else {
-                    mLimitHit[i] = hardwareHit || internalBwd || mExtSoftBwd;
-                }
-
-                result.isForwardPressed = (mLimitHit[i] && mLimitSwitchesInfo[i].limitsForward) || result.isForwardPressed;
-                result.isBackwardPressed = (mLimitHit[i] && !mLimitSwitchesInfo[i].limitsForward) || result.isBackwardPressed;
-
-                if (mLimitSwitchesInfo[i].usedForReadjustment && hardwareHit) {
-                    adjust(mLimitSwitchesInfo[i].readjustPosition);
+                    mLimitHit[i] = false;
                 }
             }
-            return result;
+
+            for (std::size_t i = 0; i < MAX_NUM_LIMIT_SWITCHES; ++i) {
+                if (!mLimitSwitchesInfo[i].present || !mLimitSwitchesInfo[i].enabled) {
+                    if (!fwdMapped) {
+                        mLimitHit[i] = fwdPressed;
+                        fwdMapped = true;
+                    } else if (!bwdMapped) {
+                        mLimitHit[i] = bwdPressed;
+                        bwdMapped = true;
+                    }
+                }
+            }
+
+            mIsFwdLimitHit = fwdPressed;
+            mIsBwdLimitHit = bwdPressed;
         }
 
         auto adjust(OutputPosition position) -> void {

--- a/esw/motor/controller.hpp
+++ b/esw/motor/controller.hpp
@@ -17,7 +17,7 @@ namespace mrover {
               mMasterName{std::move(masterName)},
               mControllerName{std::move(controllerName)},
               mDevice{mNode, mMasterName, mControllerName,
-                      [this](CANMsg_t const& msg) {
+                      [this](CANMsg_t const& msg) -> void {
                           static_cast<Derived*>(this)->processMessage(msg);
                       }} {}
 


### PR DESCRIPTION
## Summary

add absolute encoder board interface to DE
enforces soft limits as hard limits
- when `min_position` and `max_position` defined in `arm.yaml`, motor constrained to those values.

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested on arm test rig

### Did you test this in sim? 
No

### Did you test this on the rover?
Yes

### Did you add unit tests? 
No
