### PR TITLE
avoid publishing incorrect position on joint a

### DIFF
--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -3,15 +3,13 @@ arm_hw_bridge:
     joint_a:
       min_velocity: -0.08
       max_velocity: 0.08
-      #min_position: 0.0
-      #max_position: 0.35
       max_torque: 30.0
       limit_switch_0_present: true
       limit_switch_0_enabled: true
       limit_switch_0_limits_forward: true
       limit_switch_0_active_high: false
-      limit_switch_0_used_for_readjustment: false
-      limit_switch_0_readjust_position: 0.4
+      limit_switch_0_used_for_readjustment: true
+      limit_switch_0_readjust_position: 0.3418
       limit_switch_0_aux_number: 1
       limit_switch_0_aux_pin: 0
       limit_switch_1_present: true

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -95,16 +95,20 @@ namespace mrover {
             };
             ParameterWrapper::declareParameters(this, parameters);
 
-            BrushlessController<Radians>::Options jointCOpts{
-                    .query_abs_position = true,
-                    .use_abs_position = true,
-                    .abs_position_offset = mJointCOffsetTheta.get(),
-                    .query_abs_velocity = true,
-                    .use_abs_velocity = false,
-                    .abs_units_multiplier = 2.0 * M_PI // output encoder is raw/cpr, scale to rads
+            BrushlessController<Meters>::Options jointAOpts {
+                .require_homing = true
             };
 
-            mJointA = std::make_shared<BrushlessController<Meters>>(shared_from_this(), "jetson", "joint_a");
+            BrushlessController<Radians>::Options jointCOpts {
+                    .abs_units_multiplier = 2.0 * M_PI, // output encoder is raw/cpr, scale to rads
+                    .abs_position_offset = mJointCOffsetTheta.get(),
+                    .query_abs_position = true,
+                    .use_abs_position = true,
+                    .query_abs_velocity = true,
+                    .use_abs_velocity = false
+            };
+
+            mJointA = std::make_shared<BrushlessController<Meters>>(shared_from_this(), "jetson", "joint_a", jointAOpts);
             mJointB = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "joint_b");
             mJointC = std::make_shared<BrushlessController<Radians>>(shared_from_this(), "jetson", "joint_c", jointCOpts);
             mJointDE0 = std::make_shared<BrushlessController<Revolutions>>(shared_from_this(), "jetson", "joint_de_0");

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -95,18 +95,16 @@ namespace mrover {
             };
             ParameterWrapper::declareParameters(this, parameters);
 
-            BrushlessController<Meters>::Options jointAOpts {
-                .require_homing = true
-            };
+            BrushlessController<Meters>::Options jointAOpts{
+                    .require_homing = true};
 
-            BrushlessController<Radians>::Options jointCOpts {
+            BrushlessController<Radians>::Options jointCOpts{
                     .abs_units_multiplier = 2.0 * M_PI, // output encoder is raw/cpr, scale to rads
                     .abs_position_offset = mJointCOffsetTheta.get(),
                     .query_abs_position = true,
                     .use_abs_position = true,
                     .query_abs_velocity = true,
-                    .use_abs_velocity = false
-            };
+                    .use_abs_velocity = false};
 
             mJointA = std::make_shared<BrushlessController<Meters>>(shared_from_this(), "jetson", "joint_a", jointAOpts);
             mJointB = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "joint_b");

--- a/esw/motor/brushless.hpp
+++ b/esw/motor/brushless.hpp
@@ -288,7 +288,7 @@ namespace mrover {
                     if (mOptions.use_abs_position && mAbsPosExtraIndex != -1) {
                         double const rawPos = (result.extra[mAbsPosExtraIndex].value * mOptions.abs_units_multiplier) - mOptions.abs_position_offset;
                         mPosition = static_cast<float>(std::remainder(rawPos, mOptions.abs_units_multiplier));
-                    } else if (~mIsHomed) {
+                    } else if (!mIsHomed) {
                         mPosition = std::numeric_limits<float>::quiet_NaN();
                     } else {
                         mPosition = static_cast<float>(result.position);

--- a/esw/motor/brushless.hpp
+++ b/esw/motor/brushless.hpp
@@ -68,12 +68,13 @@ namespace mrover {
         using OutputVelocity = compound_unit<OutputPosition, inverse<Seconds>>;
 
         struct Options {
+            double abs_units_multiplier{2.0 * M_PI};
+            double abs_position_offset{0.0};
             bool query_abs_position{false};
             bool use_abs_position{false};
-            double abs_position_offset{0.0};
             bool query_abs_velocity{false};
             bool use_abs_velocity{false};
-            double abs_units_multiplier{2.0 * M_PI};
+            bool require_homing{false};
         };
 
     private:
@@ -115,7 +116,7 @@ namespace mrover {
         };
 
         constexpr static std::size_t MAX_NUM_LIMIT_SWITCHES = 2;
-        static_assert(MAX_NUM_LIMIT_SWITCHES <= 2, "Only 2 limit switches are supported");
+        static_assert(MAX_NUM_LIMIT_SWITCHES <= 2, "only 2 limit switches are supported");
 
         Options mOptions;
         int mAbsPosExtraIndex = -1;
@@ -136,10 +137,11 @@ namespace mrover {
         bool mIsBwdLimitHit{false};
         bool mExtSoftFwd{false};
         bool mExtSoftBwd{false};
+        bool mIsHomed{false};
 
     public:
         BrushlessController(rclcpp::Node::SharedPtr node, std::string masterName, std::string controllerName, Options options = Options{})
-            : Base{std::move(node), std::move(masterName), std::move(controllerName)}, mOptions{options} {
+            : Base{std::move(node), std::move(masterName), std::move(controllerName)}, mOptions{options}, mIsHomed{!options.require_homing} {
 
             double minVelocity, maxVelocity;
             double minPosition, maxPosition;
@@ -286,6 +288,8 @@ namespace mrover {
                     if (mOptions.use_abs_position && mAbsPosExtraIndex != -1) {
                         double const rawPos = (result.extra[mAbsPosExtraIndex].value * mOptions.abs_units_multiplier) - mOptions.abs_position_offset;
                         mPosition = static_cast<float>(std::remainder(rawPos, mOptions.abs_units_multiplier));
+                    } else if (~mIsHomed) {
+                        mPosition = std::numeric_limits<float>::quiet_NaN();
                     } else {
                         mPosition = static_cast<float>(result.position);
                     }
@@ -392,6 +396,7 @@ namespace mrover {
             moteus::OutputExact::Command const outputExactCmd{command};
             moteus::CanFdFrame positionFrame = mMoteus->MakeOutputExact(outputExactCmd);
             mDevice.publishMessage(positionFrame);
+            mIsHomed = true;
         }
 
         auto sendQuery() -> void {


### PR DESCRIPTION
## Summary
Joint A is not absolute, publish NaN on absolute position until homed by limit switch

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested on rover.

### Did you test this in sim? 
No

### Did you test this on the rover?
Yes

### Did you add unit tests? 
No
