### PR TITLE
update abs encoder ros interface (joint DE)

### DIFF
--- a/config/arm.yaml
+++ b/config/arm.yaml
@@ -35,8 +35,6 @@ arm_hw_bridge:
       max_torque: 200.0
     # Offsets are subtracted from the absolute encoder readings for pitch and roll
     # In order to zero, move the joint to the zero position and read the unadjusted positions. These should be the set to the offsets
-    joint_de_pitch_offset: -1.788 # radians
-    joint_de_roll_offset: -3.134 # radians
     joint_de_pitch_max_position: 1.39 # radians
     joint_de_pitch_min_position: -1.00 # radians
     joint_de_roll_max_position: 2.00 # radians
@@ -44,14 +42,10 @@ arm_hw_bridge:
     joint_de_0:
       min_velocity: -5.0
       max_velocity: 5.0
-      min_position: -10000.0
-      max_position: 10000.0
       max_torque: 20.0
     joint_de_1:
       min_velocity: -5.0
       max_velocity: 5.0
-      min_position: -10000.0
-      max_position: 10000.0
       max_torque: 20.0
     pusher_throttle: 1.0
     pusher_wait_duration: 5.0

--- a/esw/abs/abs.hpp
+++ b/esw/abs/abs.hpp
@@ -10,17 +10,15 @@ namespace mrover {
     class AbsoluteEncoder {
         rclcpp::Node::SharedPtr mNode;
         CANDevice mDevice;
-        bool mInvert;
 
         Radians mPosition{0.0f};
         RadiansPerSecond mVelocity{0.0f};
 
     public:
-        AbsoluteEncoder(rclcpp::Node::SharedPtr node, std::string masterName, std::string deviceName, bool invert = false)
+        AbsoluteEncoder(rclcpp::Node::SharedPtr node, std::string masterName, std::string deviceName)
             : mNode{std::move(node)},
               mDevice{mNode, std::move(masterName), std::move(deviceName),
-                      [this](CANMsg_t const& msg) -> void { processMessage(msg); }},
-              mInvert{invert} {
+                      [this](CANMsg_t const& msg) -> void { processMessage(msg); }} {
         }
 
         void processMessage(CANMsg_t const& msg) {
@@ -29,9 +27,8 @@ namespace mrover {
 
                 if constexpr (std::is_same_v<T, ABSEncoderState>) {
                     // update local state
-                    float const sign = mInvert ? -1.0f : 1.0f;
-                    mPosition = Radians{decoded.position * sign};
-                    mVelocity = RadiansPerSecond{decoded.velocity * sign};
+                    mPosition = Radians{decoded.position};
+                    mVelocity = RadiansPerSecond{decoded.velocity};
                 } else {
                     RCLCPP_WARN(mNode->get_logger(), "absolute encoder received unexpected message type %s", typeid(T).name());
                 }

--- a/esw/arm_hw_bridge.cpp
+++ b/esw/arm_hw_bridge.cpp
@@ -84,8 +84,6 @@ namespace mrover {
                     {"joint_b_mount_theta", mJointBMountTheta.rep, 0.0},
                     {"joint_b_segment_offset_theta", mJointBSegmentOffsetTheta.rep, 0.0},
                     {"joint_c_offset_theta", mJointCOffsetTheta.rep, 0.0},
-                    {"joint_de_pitch_offset", mJointDEPitchOffset.rep, 0.0},
-                    {"joint_de_roll_offset", mJointDERollOffset.rep, 0.0},
                     {"joint_de_pitch_max_position", mJointDEPitchMaxPosition.rep, std::numeric_limits<float>::infinity()},
                     {"joint_de_pitch_min_position", mJointDEPitchMinPosition.rep, -std::numeric_limits<float>::infinity()},
                     {"joint_de_roll_max_position", mJointDERollMaxPosition.rep, std::numeric_limits<float>::infinity()},
@@ -113,8 +111,8 @@ namespace mrover {
             mJointDE1 = std::make_shared<BrushlessController<Revolutions>>(shared_from_this(), "jetson", "joint_de_1");
             mGripper = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "gripper");
             mPusher = std::make_shared<BrushedController<Meters>>(shared_from_this(), "jetson", "pusher");
-            mAbsDEPitch = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_pitch", true);
-            mAbsDERoll = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_roll", true);
+            mAbsDEPitch = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_pitch");
+            mAbsDERoll = std::make_shared<AbsoluteEncoder>(shared_from_this(), "jetson", "abs_de_roll");
 
             mArmThrottleSub = create_subscription<msg::Throttle>("arm_thr_cmd", 1, [this](msg::Throttle::ConstSharedPtr const& msg) -> void { processThrottleCmd(msg); });
             mArmVelocitySub = create_subscription<msg::Velocity>("arm_vel_cmd", 1, [this](msg::Velocity::ConstSharedPtr const& msg) -> void { processVelocityCmd(msg); });
@@ -205,7 +203,6 @@ namespace mrover {
         Percent mPusherThrottle;
         float mPusherWaitDuration{}, mPusherWaitCycles{};
 
-        Radians mJointDEPitchOffset, mJointDERollOffset;
         std::optional<Vector2<Radians>> mJointDEPitchRoll; // position after offset is applied (raw - offset)
 
         Radians mJointDEPitchMaxPosition, mJointDEPitchMinPosition;
@@ -520,8 +517,8 @@ namespace mrover {
         auto updateAbsoluteOffsets() -> void {
             mJointC->adjust(mJointCOffsetTheta);
 
-            Radians const currentPitch = mAbsDEPitch->getPosition() - mJointDEPitchOffset;
-            Radians const currentRoll = mAbsDERoll->getPosition() - mJointDERollOffset;
+            Radians const currentPitch = mAbsDEPitch->getPosition();
+            Radians const currentRoll = mAbsDERoll->getPosition();
             mJointDEPitchRoll = {currentPitch, currentRoll};
 
             Vector2<Radians> motorPositionsRad = PITCH_ROLL_TO_01_SCALE * (PITCH_ROLL_TO_0_1 * mJointDEPitchRoll.value());
@@ -603,12 +600,9 @@ namespace mrover {
         auto publishDataCallback() -> void {
             mControllerState.header.stamp = now();
 
-            Radians const pitch = mAbsDEPitch->getPosition() - mJointDEPitchOffset;
-            Radians const roll = mAbsDERoll->getPosition() - mJointDERollOffset;
+            Radians const pitch = mAbsDEPitch->getPosition();
+            Radians const roll = mAbsDERoll->getPosition();
             mJointDEPitchRoll = {pitch, roll};
-            // auto const pitchWrapped = wrapAngle(mJointDE1->getPosition());
-            // auto const rollWrapped = -1 * wrapAngle(mJointDE0->getPosition());
-            // mJointDEPitchRoll = {pitchWrapped, rollWrapped};
 
             mJointDE1->setExternalSoftLimits(pitch >= mJointDEPitchMaxPosition, pitch <= mJointDEPitchMinPosition);
             mJointDE0->setExternalSoftLimits(roll >= mJointDERollMaxPosition, roll <= mJointDERollMinPosition);


### PR DESCRIPTION
## Summary
guts offsets, inversions from ros2 bridge for absolute encoder boards

see umrover/mrover-esw#68 for fw updates, zeroing functionality

### Did you add documentation to the wiki?
No

## How was this code tested? 
Tested on rover and on standalone absolute encoder setup

### Did you test this in sim? 
No

### Did you test this on the rover?
Yes

### Did you add unit tests? 
No
