### PR TITLE
zsh prompt newline

### DIFF
--- a/ansible/roles/dev/files/home/.oh-my-zsh/custom/themes/mrover.zsh-theme
+++ b/ansible/roles/dev/files/home/.oh-my-zsh/custom/themes/mrover.zsh-theme
@@ -4,9 +4,10 @@ function get_build_profile() {
   fi 
 }
 
-PROMPT="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ ) %{$fg[yellow]%}%m %{$fg[gray]%}at %{$fg[yellow]%}%d%{$reset_color%}"
+PROMPT="%{$fg[yellow]%}%m %{$fg[gray]%}at %{$fg[yellow]%}%d%{$reset_color%}"
 PROMPT+=' $(git_prompt_info)'
 PROMPT+='$(get_build_profile)'
+PROMPT+=$'\n''%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})❯%{$reset_color%} '
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[gray]%}on %{$fg[blue]%}git:(%{$fg[blue]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "


### PR DESCRIPTION
## Summary

```shell
p1-fedora at /home/kevinjin/mrover-ros2 on git:(main) * 
❯ <user input starts here>
```

add a \n, move arrow to newline, arrow inherits status color

when i was a new member and using this zsh theme, i was annoyed when long ros commands wrapped into the next line because the prompt is already quite long
have been using powerlevel10k since and its prompt on new line config, which i think is quite nice, so brought it over
feel free to close if too opinionated / unnecessary

### Did you add documentation to the wiki?
Yes/No (If not explain why not)

## How was this code tested? 
tested in terminal

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
